### PR TITLE
Adding LoginInNewDevice notificationType

### DIFF
--- a/src/bluecon/notifications/LoginInNewDevice.py
+++ b/src/bluecon/notifications/LoginInNewDevice.py
@@ -1,0 +1,18 @@
+from bluecon.notifications.INotification import INotification
+
+@INotification.register
+class LoginInNewDevice(INotification):
+    def __init__(self, notificationData: dict):
+        self.sender_id = notificationData['google.c.sender.id']
+        self.notificationTitle = notificationData['NotificationTitle']
+        self.notificationBody = notificationData['NotificationBody']
+        self.sendAcknowledge = bool(notificationData['SendAcknowledge'])
+
+    def getNotificationType(self) -> str:
+        return "Info"
+
+    def shouldAcknowledge(self) -> str:
+        return self.sendAcknowledge
+
+    def getFcmMessageId(self) -> str:
+        raise NotImplementedError

--- a/src/bluecon/notifications/NotificationBuilder.py
+++ b/src/bluecon/notifications/NotificationBuilder.py
@@ -1,6 +1,7 @@
 from bluecon.notifications.CallEndNotification import CallEndNotification
 from bluecon.notifications.CallNotification import CallNotification
 from bluecon.notifications.INotification import INotification
+from bluecon.notifications.LoginInNewDevice import LoginInNewDevice
 
 
 class NotificationBuilder:
@@ -10,5 +11,7 @@ class NotificationBuilder:
             return CallNotification(notification, notificationId)
         elif notification['FermaxNotificationType'] == "CallEnd":
             return CallEndNotification(notification)
+        elif notification['FermaxNotificationType'] == "Info":
+            return LoginInNewDevice(notification)
         else:
             raise NotImplementedError


### PR DESCRIPTION
When you receive a `LoginInNewDevice` notification, now it doesn't throw a `NotImplementedError`